### PR TITLE
Added support for blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Contributors
 ---
 
 * [Dominik Hofmann](https://github.com/dominikhofmann/)
+* [Matt Herzog](https://github.com/mattherzog/)
 
 License
 ===

--- a/example/PRTween.xcodeproj/project.pbxproj
+++ b/example/PRTween.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		B25002D8139558F700670D11 /* PRTweenExampleViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = B25002D6139558F700670D11 /* PRTweenExampleViewController.xib */; };
 		B4A2EBFD13C8AFAE006EB549 /* PRTweenTimingFunctions.m in Sources */ = {isa = PBXBuildFile; fileRef = B4A2EBFB13C8AFAE006EB549 /* PRTweenTimingFunctions.m */; };
 		B4F3069513C8BFCA00355204 /* PRTween.m in Sources */ = {isa = PBXBuildFile; fileRef = B4F3069313C8BFCA00355204 /* PRTween.m */; };
+		F3957B2813F2FA78005FD683 /* libSystem.B.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = F3957B2713F2FA78005FD683 /* libSystem.B.dylib */; settings = {ATTRIBUTES = (Weak, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -39,6 +40,7 @@
 		B4A2EBFB13C8AFAE006EB549 /* PRTweenTimingFunctions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = PRTweenTimingFunctions.m; path = ../lib/PRTweenTimingFunctions.m; sourceTree = "<group>"; };
 		B4A2EBFC13C8AFAE006EB549 /* PRTweenTimingFunctions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PRTweenTimingFunctions.h; path = ../lib/PRTweenTimingFunctions.h; sourceTree = "<group>"; };
 		B4F3069313C8BFCA00355204 /* PRTween.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = PRTween.m; path = ../lib/PRTween.m; sourceTree = "<group>"; };
+		F3957B2713F2FA78005FD683 /* libSystem.B.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libSystem.B.dylib; path = usr/lib/libSystem.B.dylib; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -46,6 +48,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F3957B2813F2FA78005FD683 /* libSystem.B.dylib in Frameworks */,
 				B25002BF139558F700670D11 /* UIKit.framework in Frameworks */,
 				B25002C1139558F700670D11 /* Foundation.framework in Frameworks */,
 				B25002C3139558F700670D11 /* CoreGraphics.framework in Frameworks */,
@@ -58,6 +61,7 @@
 		B25002AF139558F700670D11 = {
 			isa = PBXGroup;
 			children = (
+				F3957B2713F2FA78005FD683 /* libSystem.B.dylib */,
 				B262C66A1397D0550092094F /* Example */,
 				B25002C4139558F700670D11 /* PRTween */,
 				B25002BD139558F700670D11 /* Frameworks */,

--- a/example/PRTween.xcodeproj/project.pbxproj
+++ b/example/PRTween.xcodeproj/project.pbxproj
@@ -18,7 +18,6 @@
 		B25002D8139558F700670D11 /* PRTweenExampleViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = B25002D6139558F700670D11 /* PRTweenExampleViewController.xib */; };
 		B4A2EBFD13C8AFAE006EB549 /* PRTweenTimingFunctions.m in Sources */ = {isa = PBXBuildFile; fileRef = B4A2EBFB13C8AFAE006EB549 /* PRTweenTimingFunctions.m */; };
 		B4F3069513C8BFCA00355204 /* PRTween.m in Sources */ = {isa = PBXBuildFile; fileRef = B4F3069313C8BFCA00355204 /* PRTween.m */; };
-		F3957B2813F2FA78005FD683 /* libSystem.B.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = F3957B2713F2FA78005FD683 /* libSystem.B.dylib */; settings = {ATTRIBUTES = (Weak, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -40,7 +39,6 @@
 		B4A2EBFB13C8AFAE006EB549 /* PRTweenTimingFunctions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = PRTweenTimingFunctions.m; path = ../lib/PRTweenTimingFunctions.m; sourceTree = "<group>"; };
 		B4A2EBFC13C8AFAE006EB549 /* PRTweenTimingFunctions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PRTweenTimingFunctions.h; path = ../lib/PRTweenTimingFunctions.h; sourceTree = "<group>"; };
 		B4F3069313C8BFCA00355204 /* PRTween.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = PRTween.m; path = ../lib/PRTween.m; sourceTree = "<group>"; };
-		F3957B2713F2FA78005FD683 /* libSystem.B.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libSystem.B.dylib; path = usr/lib/libSystem.B.dylib; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -48,7 +46,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F3957B2813F2FA78005FD683 /* libSystem.B.dylib in Frameworks */,
 				B25002BF139558F700670D11 /* UIKit.framework in Frameworks */,
 				B25002C1139558F700670D11 /* Foundation.framework in Frameworks */,
 				B25002C3139558F700670D11 /* CoreGraphics.framework in Frameworks */,
@@ -61,7 +58,6 @@
 		B25002AF139558F700670D11 = {
 			isa = PBXGroup;
 			children = (
-				F3957B2713F2FA78005FD683 /* libSystem.B.dylib */,
 				B262C66A1397D0550092094F /* Example */,
 				B25002C4139558F700670D11 /* PRTween */,
 				B25002BD139558F700670D11 /* Frameworks */,

--- a/example/PRTweenExampleAppDelegate.m
+++ b/example/PRTweenExampleAppDelegate.m
@@ -12,8 +12,14 @@
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
     // Override point for customization after application launch.
-     
-    self.window.rootViewController = self.viewController;
+    
+    // Check to make sure can set rootviewcontroller (available > 4.0)
+    if ([self.window respondsToSelector:@selector(setRootViewController:)]) {
+        self.window.rootViewController = self.viewController;
+    } else {
+        [self.window addSubview:self.viewController.view];
+    }
+
     [self.window makeKeyAndVisible];
     return YES;
 }

--- a/example/PRTweenExampleViewController.m
+++ b/example/PRTweenExampleViewController.m
@@ -29,21 +29,63 @@
     [[PRTween sharedInstance] removeTweenOperation:activeTweenOperation];
     
     PRTweenPeriod *period = [PRTweenPeriod periodWithStartValue:0.0 endValue:904 duration:1.5];
-    activeTweenOperation = [[PRTween sharedInstance] addTweenPeriod:period target:self selector:@selector(update:)];
+    
+    if (kCFCoreFoundationVersionNumber >= kCFCoreFoundationVersionNumber_iOS_4_0)
+    {
+        activeTweenOperation = [[PRTween sharedInstance] addTweenPeriod:period
+                                                            updateBlock:^(PRTweenPeriod *period) {
+                                                                [self update:period];
+                                                            }
+                                                        completionBlock:^{
+                                                            NSLog(@"Completion");
+                                                        }];
+        
+    }
+    else
+    {
+        activeTweenOperation = [[PRTween sharedInstance] addTweenPeriod:period target:self selector:@selector(update:)];        
+    }
 }
 
 - (IBAction)bounceOutTapped {
     [[PRTween sharedInstance] removeTweenOperation:activeTweenOperation];
     
     PRTweenPeriod *period = [PRTweenPeriod periodWithStartValue:0.0 endValue:904 duration:1.5];
-    activeTweenOperation = [[PRTween sharedInstance] addTweenPeriod:period target:self selector:@selector(update:) timingFunction:&PRTweenTimingFunctionBounceOut];
+
+    if (kCFCoreFoundationVersionNumber >= kCFCoreFoundationVersionNumber_iOS_4_0) {
+        activeTweenOperation = [[PRTween sharedInstance] addTweenPeriod:period
+                                                            updateBlock:^(PRTweenPeriod *period) {
+                                                                [self update:period];
+                                                            }
+                                                        completionBlock:^{
+                                                            NSLog(@"Completion");
+                                                        }
+                                                         timingFunction:&PRTweenTimingFunctionBounceOut];
+        
+    } else {
+        activeTweenOperation = [[PRTween sharedInstance] addTweenPeriod:period target:self selector:@selector(update:) timingFunction:&PRTweenTimingFunctionBounceOut];        
+    }
+
 }
 
 - (IBAction)bounceInTapped {
     [[PRTween sharedInstance] removeTweenOperation:activeTweenOperation];
     
     PRTweenPeriod *period = [PRTweenPeriod periodWithStartValue:0.0 endValue:904 duration:1.5];
-    activeTweenOperation = [[PRTween sharedInstance] addTweenPeriod:period target:self selector:@selector(update:) timingFunction:&PRTweenTimingFunctionBounceIn];
+    
+    if (kCFCoreFoundationVersionNumber >= kCFCoreFoundationVersionNumber_iOS_4_0) {
+        activeTweenOperation = [[PRTween sharedInstance] addTweenPeriod:period
+                                                            updateBlock:^(PRTweenPeriod *period) {
+                                                                [self update:period];
+                                                            }
+                                                        completionBlock:^{
+                                                            NSLog(@"Completion");
+                                                        }
+                                                         timingFunction:&PRTweenTimingFunctionBounceIn];
+    }
+    else {
+        activeTweenOperation = [[PRTween sharedInstance] addTweenPeriod:period target:self selector:@selector(update:) timingFunction:&PRTweenTimingFunctionBounceIn];
+    }
 }
 
 - (IBAction)bounceOutDelayTapped {
@@ -51,14 +93,40 @@
     
     PRTweenPeriod *period = [PRTweenPeriod periodWithStartValue:0.0 endValue:904 duration:1.5];
     period.delay = 1.5;
-    activeTweenOperation = [[PRTween sharedInstance] addTweenPeriod:period target:self selector:@selector(update:) timingFunction:&PRTweenTimingFunctionBounceOut];
+    
+    if (kCFCoreFoundationVersionNumber >= kCFCoreFoundationVersionNumber_iOS_4_0) {
+        activeTweenOperation = [[PRTween sharedInstance] addTweenPeriod:period
+                                                            updateBlock:^(PRTweenPeriod *period) {
+                                                                [self update:period];
+                                                            }
+                                                        completionBlock:^{
+                                                            NSLog(@"Completion");
+                                                        }
+                                                         timingFunction:&PRTweenTimingFunctionBounceOut];
+    }
+    else {
+        activeTweenOperation = [[PRTween sharedInstance] addTweenPeriod:period target:self selector:@selector(update:) timingFunction:&PRTweenTimingFunctionBounceOut];
+    }
 }
 
 - (IBAction)quintOutTapped {
     [[PRTween sharedInstance] removeTweenOperation:activeTweenOperation];
     
     PRTweenPeriod *period = [PRTweenPeriod periodWithStartValue:0.0 endValue:904 duration:0.6];
-    activeTweenOperation = [[PRTween sharedInstance] addTweenPeriod:period target:self selector:@selector(update:) timingFunction:&PRTweenTimingFunctionQuintOut];
+    
+    if (kCFCoreFoundationVersionNumber >= kCFCoreFoundationVersionNumber_iOS_4_0) {
+        activeTweenOperation = [[PRTween sharedInstance] addTweenPeriod:period
+                                                            updateBlock:^(PRTweenPeriod *period) {
+                                                                [self update:period];
+                                                            }
+                                                        completionBlock:^{
+                                                            NSLog(@"Completion");
+                                                        }
+                                                         timingFunction:&PRTweenTimingFunctionQuintOut];
+    }
+    else {
+        activeTweenOperation = [[PRTween sharedInstance] addTweenPeriod:period target:self selector:@selector(update:) timingFunction:&PRTweenTimingFunctionQuintOut];
+    }
 }
 
 - (void)viewDidUnload

--- a/lib/PRTween.h
+++ b/lib/PRTween.h
@@ -1,5 +1,6 @@
 
 #import <Foundation/Foundation.h>
+
 #import "PRTweenTimingFunctions.h"
 
 @interface PRTweenPeriod : NSObject {
@@ -28,6 +29,11 @@
     SEL updateSelector;
     SEL completeSelector;
     CGFloat (*timingFunction)(CGFloat, CGFloat, CGFloat, CGFloat);
+    
+#if NS_BLOCKS_AVAILABLE
+    void (^completionBlock)();
+    void (^updateBlock)(PRTweenPeriod *period);    
+#endif
 }
 
 @property (nonatomic, retain) PRTweenPeriod *period;
@@ -35,6 +41,11 @@
 @property (nonatomic) SEL updateSelector;
 @property (nonatomic) SEL completeSelector;
 @property (nonatomic, assign) CGFloat (*timingFunction)(CGFloat, CGFloat, CGFloat, CGFloat);
+
+#if NS_BLOCKS_AVAILABLE
+@property (nonatomic, copy) void (^updateBlock)(PRTweenPeriod *period);
+@property (nonatomic, copy) void (^completionBlock)();
+#endif
 
 @end
 
@@ -49,6 +60,12 @@
 
 + (PRTween *)sharedInstance;
 - (PRTweenOperation*)addOperation:(PRTweenOperation*)operation;
+
+#if NS_BLOCKS_AVAILABLE
+- (PRTweenOperation*)addTweenPeriod:(PRTweenPeriod *)period updateBlock:(void (^)(PRTweenPeriod *period))updateBlock completionBlock:(void (^)())completionBlock;
+- (PRTweenOperation*)addTweenPeriod:(PRTweenPeriod *)period updateBlock:(void (^)(PRTweenPeriod *period))updateBlock completionBlock:(void (^)())completionBlock timingFunction:(CGFloat (*)(CGFloat, CGFloat, CGFloat, CGFloat))timingFunction;
+#endif
+
 - (PRTweenOperation*)addTweenPeriod:(PRTweenPeriod *)period target:(NSObject *)target selector:(SEL)selector;
 - (PRTweenOperation*)addTweenPeriod:(PRTweenPeriod *)period target:(NSObject *)target selector:(SEL)selector timingFunction:(CGFloat (*)(CGFloat, CGFloat, CGFloat, CGFloat))timingFunction;
 - (void)removeTweenOperation:(PRTweenOperation*)tweenOperation;


### PR DESCRIPTION
*Added support for an update block as well as a completion block.

*Updated the example view controller to use blocks if runtime iOS version is >= 4, otherwise it will use target/selector. Tested this using iPad 3.2 as destination.
