### PR TITLE
Cancellable tween operations

### DIFF
--- a/lib/PRTween.h
+++ b/lib/PRTween.h
@@ -114,9 +114,10 @@ typedef void (^PRTweenCompleteBlock)();
 @property (nonatomic) BOOL override;
 @property (nonatomic) BOOL invalid;
 
+- (void)invalidate;
+
 @end
 
-- (void)invalidate;
 
 @interface PRTweenCGPointLerp : NSObject
 + (PRTweenOperation *)lerp:(id)object property:(NSString*)property from:(CGPoint)from to:(CGPoint)to duration:(CGFloat)duration timingFunction:(PRTweenTimingFunction)timingFunction target:(NSObject *)target completeSelector:(SEL)selector;

--- a/lib/PRTween.h
+++ b/lib/PRTween.h
@@ -85,6 +85,8 @@ typedef void (^PRTweenCompleteBlock)();
     
     BOOL override;
     
+    BOOL invalid;
+
 #if NS_BLOCKS_AVAILABLE
     PRTweenUpdateBlock updateBlock;
     PRTweenCompleteBlock completeBlock; 
@@ -110,8 +112,11 @@ typedef void (^PRTweenCompleteBlock)();
 @property (nonatomic) SEL boundGetter;
 @property (nonatomic) SEL boundSetter;
 @property (nonatomic) BOOL override;
+@property (nonatomic) BOOL invalid;
 
 @end
+
+- (void)invalidate;
 
 @interface PRTweenCGPointLerp : NSObject
 + (PRTweenOperation *)lerp:(id)object property:(NSString*)property from:(CGPoint)from to:(CGPoint)to duration:(CGFloat)duration timingFunction:(PRTweenTimingFunction)timingFunction target:(NSObject *)target completeSelector:(SEL)selector;


### PR DESCRIPTION
Added a BOOL flag to tween operation. when this is set to YES, the tween operation is cancelled.

Im using a tween to add animations when the user finished interacting with a collection view, but I need to cancel these animations if the user begins interacting with the view again before the animations finish.
