### PR TITLE
FIXES: Changes to the way NSTimer behaves (#35, #36)

### DIFF
--- a/lib/PRTween.h
+++ b/lib/PRTween.h
@@ -148,6 +148,7 @@ typedef void (^PRTweenCompleteBlock)();
     NSMutableArray *expiredTweenOperations;
     NSTimer *timer;
     CGFloat timeOffset;
+    CFTimeInterval lastAbsoluteTime;
     
     PRTweenTimingFunction defaultTimingFunction;
     BOOL useBuiltInAnimationsWhenPossible;

--- a/lib/PRTween.m
+++ b/lib/PRTween.m
@@ -433,6 +433,7 @@ static NSArray *animationSelectorsForUIView = nil;
     
     // create new timer if there are no operations running
     if (timer == nil) {
+        lastAbsoluteTime = 0;
         timer = [NSTimer scheduledTimerWithTimeInterval:kPRTweenFramerate target:self selector:@selector(update) userInfo:nil repeats:YES];
     }
     
@@ -631,7 +632,9 @@ complete:
 }
 
 - (void)update {
-    timeOffset += kPRTweenFramerate;
+    // increase the timeOffset by the actual amount of time that has passed
+    timeOffset += (lastAbsoluteTime == 0) ? kPRTweenFramerate : (CFAbsoluteTimeGetCurrent() - lastAbsoluteTime);
+    lastAbsoluteTime = CFAbsoluteTimeGetCurrent();
     
     for (PRTweenOperation *tweenOperation in tweenOperations) {
         

--- a/lib/PRTween.m
+++ b/lib/PRTween.m
@@ -424,15 +424,17 @@ static NSArray *animationSelectorsForUIView = nil;
         tweenOperations = [[NSMutableArray alloc] init];
         expiredTweenOperations = [[NSMutableArray alloc] init];
         timeOffset = 0;
-        if (timer == nil) {
-            timer = [NSTimer scheduledTimerWithTimeInterval:kPRTweenFramerate target:self selector:@selector(update) userInfo:nil repeats:YES];
-        }
         self.defaultTimingFunction = &PRTweenTimingFunctionQuadInOut;
     }
     return self;
 }
 
 - (PRTweenOperation*)addTweenOperation:(PRTweenOperation*)operation {
+    
+    // create new timer if there are no operations running
+    if (timer == nil) {
+        timer = [NSTimer scheduledTimerWithTimeInterval:kPRTweenFramerate target:self selector:@selector(update) userInfo:nil repeats:YES];
+    }
     
     if (useBuiltInAnimationsWhenPossible && !operation.override) {
     
@@ -714,6 +716,13 @@ complete:
         tweenOperation = nil;
     }
     [expiredTweenOperations removeAllObjects];
+    
+    // remove timer if all operations have finished
+    if(tweenOperations.count == 0)
+    {
+        [timer invalidate];
+        timer = nil;
+    }
 }
 
 - (void)dealloc {


### PR DESCRIPTION
I've submitted a couple of issues as mentioned above, which deal with the way NSTimer works... Firstly, removing NSTimer when it is not in use to save processor cycles, and a calculated time difference so that tweens run at the correct speed if the runloop falls below 60 fps (which it does on my project).
